### PR TITLE
Fix iOS Simulator scrolling in incidents side menu

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -57,6 +57,9 @@ body {
       }
     }
   }
+  .incidents-content {
+    margin-top: 85px;
+  }
 }
 
 .incidents-item {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -32,6 +32,8 @@ body {
     padding-right: 20px; }
     .incidents .incidents-header label.incidents-search-box i.incidents-clear-search {
       cursor: pointer; }
+.incidents .incidents-content {
+  margin-top: 85px; }
 
 .incidents-item {
   padding: 16px;

--- a/www/templates/home.incidents.html
+++ b/www/templates/home.incidents.html
@@ -12,7 +12,7 @@
   </md-toolbar>
 
   <!-- Incidents Content -->
-  <md-content class="incidents-content">
+  <ion-content class="incidents-content">
     <ion-refresher pulling-text="Pull to refresh" on-refresh="home.IncidentsController.refreshIncidentsList()">
     </ion-refresher>
     <ion-list>
@@ -29,5 +29,5 @@
         </div>
       </ion-item>
     </ion-list>
-  </md-content>
+  </ion-content>
 </md-sidenav>


### PR DESCRIPTION
Incidents side menu was not scrolling in the iOS Simulator.  Fixed so that it works in both the browser and simulator.
